### PR TITLE
Added call to close() function for 'file_train' and 'file_test'

### DIFF
--- a/yolov4/process.py
+++ b/yolov4/process.py
@@ -26,3 +26,6 @@ for pathAndFilename in glob.iglob(os.path.join(current_dir, "*.jpg")):
     else:
         file_train.write("data/obj" + "/" + title + '.jpg' + "\n")
         counter = counter + 1
+
+file_train.close()
+file_test.close()


### PR DESCRIPTION
#### Reference Issues
None

#### What does this  fix?
In 99.9% of the cases not closing an opened txt file is not going to do any harm, but still it is best practice to do so. In the "process.py" script the two files "train.txt" and "test.txt" are opened with open() but never closed.

#### Other comments
Your tutorials have helped me a lot while configuring/using the darknet framework, thank you! 💖